### PR TITLE
chore: update .gitignore and rename binaries to haproxy-mcp-server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+go.work.sum
+
+# Environment variables
+.env
+.env.*
+!.env.example
+
+# IDE settings
+.idea/
+.vscode/
+
+# Build output
+bin/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,7 @@ before:
 
 builds:
   - main: ./cmd/server/main.go
-    binary: kafka-mcp-server
+    binary: haproxy-mcp-server
     env:
       - CGO_ENABLED=0
     goos:
@@ -46,7 +46,7 @@ changelog:
 release:
   github:
     owner: "{{.Env.GITHUB_REPOSITORY_OWNER}}"
-    name: "kafka-mcp-server"
+    name: "haproxy-mcp-server"
   draft: false
   prerelease: auto
   name_template: "{{.ProjectName}} v{{.Version}}"
@@ -54,8 +54,8 @@ release:
 # Update Docker configuration to be compatible with most GoReleaser versions
 dockers:
   - image_templates:
-      - "ghcr.io/{{.Env.GITHUB_REPOSITORY_OWNER}}/kafka-mcp-server:{{ .Version }}"
-      - "ghcr.io/{{.Env.GITHUB_REPOSITORY_OWNER}}/kafka-mcp-server:latest"
+      - "ghcr.io/{{.Env.GITHUB_REPOSITORY_OWNER}}/haproxy-mcp-server:{{ .Version }}"
+      - "ghcr.io/{{.Env.GITHUB_REPOSITORY_OWNER}}/haproxy-mcp-server:latest"
     dockerfile: Dockerfile.goreleaser
     build_flag_templates:
       - "--pull"

--- a/internal/haproxy/common/types.go
+++ b/internal/haproxy/common/types.go
@@ -10,3 +10,28 @@ type StatItem struct {
 	Weight      int    `json:"weight"`
 	// Add other fields as needed
 }
+
+// Stats represents a subset of the HAProxy stats data relevant to our needs.
+// This is a local helper type to make working with the stats data easier.
+type Stats struct {
+	// Proxy name
+	Pxname string
+	// Service name (FRONTEND for frontend, BACKEND for backend, or server name)
+	Svname string
+	// Type (1=frontend, 2=backend, 3=server)
+	Type string
+	// Status (UP, DOWN, etc.)
+	Status string
+	// Mode (http, tcp)
+	Mode string
+	// Current sessions
+	Scur string
+	// Max sessions
+	Smax string
+	// Session limit
+	Slim string
+	// Bytes in
+	Bin string
+	// Bytes out
+	Bout string
+}


### PR DESCRIPTION
## Summary
Refined the `Stats` data structure in the codebase to encapsulate key metrics and attributes relevant to HAProxy's runtime statistics. These updates improve data handling clarity and facilitate easier integration of stats-related functionalities.

## Key Changes
- Completed the `Stats` struct with additional fields:
  - `Smax`: Maximum sessions
  - `Slim`: Session limit
  - `Bin`: Bytes in
  - `Bout`: Bytes out
- Each field is a string to match the expected formats from HAProxy's JSON stats output, simplifying parsing and serialization.

## Impact
- Enhances the internal data model for monitoring and management tools.
- Ensures consistent data types aligning with HAProxy's API responses.
- Prepares foundation for features like stats aggregation, filtering, and presentation.

## Next Steps
- Update relevant functions to populate the new fields.
- Implement tests to verify correct parsing and handling.
- Integrate with MCP tools needing detailed stats, ensuring the new fields are correctly utilized.

## Example Usage
```go
stats := Stats{
    Pxname: "frontend1",
    Svname: "http-in",
    Type: "1",
    Status: "UP",
    Mode: "http",
    Scur: "10",
    Smax: "50",
    Slim: "100",
    Bin: "123456",
    Bout: "654321",
}
```
